### PR TITLE
Location spoof mode added to home menu

### DIFF
--- a/UniExplore/base/templates/base/home.html
+++ b/UniExplore/base/templates/base/home.html
@@ -42,7 +42,7 @@
             <style>
                 #map { height: 500px; width: 1000px }
             </style>
-            <button id="devModeSwitch">Enable Debug mode</button>
+            <button id="devModeSwitch">Enable spoof mode</button>
         </div>
 
 
@@ -67,7 +67,7 @@
     const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
 
     // this function starts the location watcher
-    function startLocator(map) {
+    function startLocator(map, marker=null) {
         if (navigator.geolocation) {
             // watchposition ties a method to every time the user's location changes;
             // here it'll run displayposition, using the getposition return values as the args
@@ -85,23 +85,26 @@
                 maximumAge: 5000
             };
             
-            {% load static %}
-            // Creating user marker to move it around with location
-            var userIcon = L.icon({
-                iconUrl:        "{% static 'images/userMarker.png' %}",
-                iconSize:       [25, 41], // size of the icon
-                iconAnchor:     [12.5, 41], // point of the icon which will correspond to marker's location
-                popupAnchor:    [0, -41], // point from which the popup should open relative to the iconAnchor
-                shadowUrl:      "{% static 'images/userMarkerShadow.png' %}",
-                shadowAnchor:   [7,25],
-                shadowSize:     [25, 25]
-            });
-            
-            var usermarker = L.marker([0,0], {icon: userIcon});
-            usermarker.bindPopup("<b>You are here!</b>");
-            usermarker.addTo(map);
+            if (marker == null){
+                {% load static %}
+                // Creating user marker to move it around with location
+                var userIcon = L.icon({
+                    iconUrl:        "{% static 'images/userMarker.png' %}",
+                    iconSize:       [25, 41], // size of the icon
+                    iconAnchor:     [12.5, 41], // point of the icon which will correspond to marker's location
+                    popupAnchor:    [0, -41], // point from which the popup should open relative to the iconAnchor
+                    shadowUrl:      "{% static 'images/userMarkerShadow.png' %}",
+                    shadowAnchor:   [7,25],
+                    shadowSize:     [25, 25]
+                });
+                
+                var usermarker = L.marker([0,0], {icon: userIcon});
+                usermarker.bindPopup("<b>You are here!</b>");
+                usermarker.addTo(map);
+            } 
 
             // it'll run success if loc gotten, error, if not.
+            // Helpful to return watchID and usermarker if we need to use them
             return [navigator.geolocation.watchPosition(success, error, options), usermarker];
         } else {
             console.log("User has declined geolocation access");
@@ -176,19 +179,33 @@
         // These are all dev mode loads
         // This shouldn't render in the template when not a gamemaster/superuser
         var button = document.getElementById('devModeSwitch');
+        var devModeOn = false;
         button.addEventListener("click", function() {
-            // Clearing geolocation watcher
-            navigator.geolocation.clearWatch(watcher[0]);
+            if (devModeOn){
+                //returning to normal settings
+                map.off('click');
+                map.removeLayer(watcher[1]);
+                watcher = startLocator(map);
+                devModeOn = false;
+                button.innerHTML = "Enable spoof mode";
+            } else {
+                // Clearing geolocation watcher
+                navigator.geolocation.clearWatch(watcher[0]);
 
-            // Onclick for moving user marker
-            map.on('click', function(e){
-                lat = e.latlng.lat;
-                lon = e.latlng.lng;
+                // Onclick for moving user marker
+                map.on('click', function(e){
+                    lat = e.latlng.lat;
+                    lon = e.latlng.lng;
 
-                console.log("Lat: "+ lat + ", Lon:"+lon );
+                    console.log("Lat: "+ lat + ", Lon:"+lon );
 
-                watcher[1].setLatLng([lat, lon]).addTo(map);
-            });
+                    watcher[1].setLatLng([lat, lon]).addTo(map);
+
+                    devModeOn = true;
+                });
+
+                button.innerHTML = "Disable spoof mode";
+            }
         });
     };
 

--- a/UniExplore/base/templates/base/home.html
+++ b/UniExplore/base/templates/base/home.html
@@ -72,7 +72,14 @@
             // watchposition ties a method to every time the user's location changes;
             // here it'll run displayposition, using the getposition return values as the args
             function success (position){
-                displayPosition( map, usermarker, position );
+                usermarker.setLatLng([position.coords.latitude, position.coords.longitude]).addTo(map);
+
+                var addedLoc = position.coords.latitude + ", " +
+                position.coords.longitude +
+                " at " + position.timestamp;
+
+                console.log(addedLoc);
+
             }
 
             function error(err) {
@@ -109,17 +116,6 @@
         } else {
             console.log("User has declined geolocation access");
         }
-    }
-
-    // This will display function on the map and log it
-    function displayPosition(map, usermarker, position) {
-        usermarker.setLatLng([position.coords.latitude, position.coords.longitude]).addTo(map);
-        
-        var addedLoc = position.coords.latitude + ", " +
-            position.coords.longitude +
-            " at " + position.timestamp;
-
-        console.log(addedLoc);
     }
 
     // This is a framework for location posting to the home server 
@@ -204,6 +200,7 @@
                     devModeOn = true;
                 });
 
+                devModeOn = true;
                 button.innerHTML = "Disable spoof mode";
             }
         });

--- a/UniExplore/base/templates/base/home.html
+++ b/UniExplore/base/templates/base/home.html
@@ -80,6 +80,7 @@
 
                 console.log(addedLoc);
 
+                postPosition(position.coords.latitude, position.coords.longitude);
             }
 
             function error(err) {
@@ -119,15 +120,15 @@
     }
 
     // This is a framework for location posting to the home server 
-    function postPosition(position) {
+    function postPosition(lat, lon) {
         var req = new XMLHttpRequest();
         var url = "/";
 
         req.onreadystatechange = function() {
             if (this.readyState == 4 && this.status == 200) {
-                alert("200");
+                console.log("server got location and response is 200")
             } else if (this.readyState == 4 && this.status != 200) {
-                alert("!200");
+                console.log("server got location and response is not 200")
             }
         };
         
@@ -136,7 +137,8 @@
         req.setRequestHeader('X-CSRFToken', csrftoken)
         req.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
 
-        req.send(JSON.stringify(posToObject(position)));
+        var pos = {"lat": lat, "lon": lon}
+        req.send(JSON.stringify(pos));
     }
 
     // This is required to be able to properly strigify the result from geolocation fetching
@@ -197,7 +199,7 @@
 
                     watcher[1].setLatLng([lat, lon]).addTo(map);
 
-                    devModeOn = true;
+                    postPosition(lat,lon);
                 });
 
                 devModeOn = true;

--- a/UniExplore/base/templates/base/home.html
+++ b/UniExplore/base/templates/base/home.html
@@ -179,6 +179,16 @@
         button.addEventListener("click", function() {
             // Clearing geolocation watcher
             navigator.geolocation.clearWatch(watcher[0]);
+
+            // Onclick for moving user marker
+            map.on('click', function(e){
+                lat = e.latlng.lat;
+                lon = e.latlng.lng;
+
+                console.log("Lat: "+ lat + ", Lon:"+lon );
+
+                watcher[1].setLatLng([lat, lon]).addTo(map);
+            });
         });
     };
 

--- a/UniExplore/base/templates/base/home.html
+++ b/UniExplore/base/templates/base/home.html
@@ -42,6 +42,7 @@
             <style>
                 #map { height: 500px; width: 1000px }
             </style>
+            <button id="devModeSwitch">Enable Debug mode</button>
         </div>
 
 
@@ -101,7 +102,7 @@
             usermarker.addTo(map);
 
             // it'll run success if loc gotten, error, if not.
-            navigator.geolocation.watchPosition(success, error, options);
+            return [navigator.geolocation.watchPosition(success, error, options), usermarker];
         } else {
             console.log("User has declined geolocation access");
         }
@@ -152,7 +153,6 @@
         }
     }
 
-
     // Initializing everything
     window.onload = function(){
         map = mapgen('map');
@@ -168,9 +168,18 @@
             "<br>" + {{'"'}}{{challenge.description|safe}}{{'"'}}).addTo(map);
         {% endfor %}
 
-        startLocator(map);
+        // Returns the watcher ID and user marker in an array of len 2
+        watcher = startLocator(map);
 
         map.invalidateSize();
+
+        // These are all dev mode loads
+        // This shouldn't render in the template when not a gamemaster/superuser
+        var button = document.getElementById('devModeSwitch');
+        button.addEventListener("click", function() {
+            // Clearing geolocation watcher
+            navigator.geolocation.clearWatch(watcher[0]);
+        });
     };
 
     // Probably separate this into another file, with tweaks available for range etc

--- a/UniExplore/base/templates/base/home.html
+++ b/UniExplore/base/templates/base/home.html
@@ -141,18 +141,6 @@
         req.send(JSON.stringify(pos));
     }
 
-    // This is required to be able to properly strigify the result from geolocation fetching
-    function posToObject (position) {
-        // there might be more data worth returning but this is probably what's useful to us
-        return {
-            timestamp: position.timestamp,
-            coords: {
-                accuracy: position.coords.accuracy,
-                latitude: position.coords.latitude,
-                longitude: position.coords.longitude,
-            }
-        }
-    }
 
     // Initializing everything
     window.onload = function(){


### PR DESCRIPTION
To test user location posting:
- Run the server
- Approve geolocation access
- Open javascript console (inspect element/f12)
- Ensure message "server got location and response is 200" is in log
- Ensure data is being sent on the network graph

To test location spoofing:
- Run the server
- Approve geolocation access
- Click "enable spoof mode"
- Click on map
- Open javascript console (inspect element/f12)
- Ensure message "server got location and response is 200" is in log
- Ensure data is being sent on the network graph
- Disable spoof mode
- Verify location posting works again

Details:
Added spoof mode and button
Made spoof mode a toggle option
Modified posting code
Enabled location posting (sent as json file {"lat":lat, "lon":lon})
Got rid of unnecessary functions

TODO:
In template, ensure spoofing scripts and button only render if user is either gamemaster or superuser
i.e include {% if %} blocks to control who can access this feature