### PR TITLE
Reject registration with existing email

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,9 @@
 UniExplore is an application designed to help students explore their university and connect with their peers. Students can complete challenges at various locations across campus, see what their classmates did for those challenges, and like the responses of others.
 
 ## Prerequisites:
+In the root directory run:
 
-- pip install django 
-- pip install django-axes
-- pip install python-decouple
-- pip install msal
-- pip install PyYAML
-- pip install python-dateutil
-- pip install coverage
-- pip install flake8
+    pip install -r requirements.txt
 
 ## Getting Started
 

--- a/UniExplore/auth_helper.py
+++ b/UniExplore/auth_helper.py
@@ -47,7 +47,10 @@ def get_token_from_code(request):
 
     # Get the flow saved in session
     flow = request.session.pop('auth_flow', {})
-    result = auth_app.acquire_token_by_auth_code_flow(flow, request.GET)
+    try:
+        result = auth_app.acquire_token_by_auth_code_flow(flow, request.GET)
+    except:
+        return None
     save_cache(request, cache)
 
     return result

--- a/UniExplore/base/views.py
+++ b/UniExplore/base/views.py
@@ -380,6 +380,9 @@ def sign_out_sso(request):
 def callback(request):
     # Make the token request
     result = get_token_from_code(request)
+    if result == None:
+        messages.warning(request, 'Failed login')
+        return HttpResponseRedirect(reverse("login"))
 
     # Get the user's profile from graph_helper.py script
     user_details = get_user(result['access_token'])

--- a/UniExplore/base/views.py
+++ b/UniExplore/base/views.py
@@ -120,7 +120,7 @@ def registerPage(request):
                 messages.success(request, f'Account created for {username}!')
                 return redirect('home')
 
-            messages.warning(request, "User with this email already exists")
+            messages.warning(request, "A User with this email already exists")
             return redirect('login')
             
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+django 
+django-axes
+python-decouple
+msal
+PyYAML
+python-dateutil
+coverage
+flake8


### PR DESCRIPTION
To Test:
- create a user with an email that is not in use
- try creating a different user with the same email
- you should be redirected to the login page saying "A User with this email already exists"
Details:
- users can now only register with an email that has not already been registered with