### PR TITLE
Only accept Exeter email

### DIFF
--- a/UniExplore/auth_helper.py
+++ b/UniExplore/auth_helper.py
@@ -47,7 +47,10 @@ def get_token_from_code(request):
 
     # Get the flow saved in session
     flow = request.session.pop('auth_flow', {})
-    result = auth_app.acquire_token_by_auth_code_flow(flow, request.GET)
+    try:
+        result = auth_app.acquire_token_by_auth_code_flow(flow, request.GET)
+    except:
+        return None
     save_cache(request, cache)
 
     return result

--- a/UniExplore/base/views.py
+++ b/UniExplore/base/views.py
@@ -380,6 +380,9 @@ def sign_out_sso(request):
 def callback(request):
     # Make the token request
     result = get_token_from_code(request)
+    if result == None:
+        messages.warning(request, 'Failed login')
+        return HttpResponseRedirect(reverse("login"))
 
     # Get the user's profile from graph_helper.py script
     user_details = get_user(result['access_token'])

--- a/UniExplore/base/views.py
+++ b/UniExplore/base/views.py
@@ -90,6 +90,10 @@ def logoutUser(request):
     logout(request)
     return redirect('home')
 
+# Checks to see if an email is valid given a valid suffix
+def is_valid_email(email, valid_suffix):
+    ending = email.split('@')[1].lower()
+    return valid_suffix.lower() == ending
 
 # User registration
 def registerPage(request):
@@ -104,26 +108,29 @@ def registerPage(request):
         if form.is_valid():
             email = form.cleaned_data.get('email')
             username = form.cleaned_data.get('username')
-            try:
-               # Check to see if there is already a user with the same email registered
-               User.objects.get(email=email)
-            except BaseException:
-                user = form.save()
-                user.backend = 'django.contrib.auth.backends.ModelBackend'  # Sets the backend authenticaion model
 
-                Profile.objects.create(
-                    user=user,
-                    name=user.username
-                )
+            if is_valid_email(email, 'exeter.ac.uk'):
+                try:
+                     # Check to see if there is already a user with the same email registered
+                    User.objects.get(email=email)
+                except BaseException:
+                    user = form.save()
+                    user.backend = 'django.contrib.auth.backends.ModelBackend'  # Sets the backend authenticaion model
 
-                login(request, user)
-                messages.success(request, f'Account created for {username}!')
-                return redirect('home')
+                    Profile.objects.create(
+                        user=user,
+                        name=user.username
+                 )
 
-            messages.warning(request, "A User with this email already exists")
-            return redirect('login')
-            
+                    login(request, user)
+                    messages.success(request, f'Account created for {username}!')
+                    return redirect('home')
 
+                messages.warning(request, "A User with this email already exists")
+                return redirect('login')
+            else:
+                messages.warning(request, "Must sign up with an email ending in exeter.ac.uk")
+                return redirect('login')
     context = {'form': form}
     return render(request, 'base/login_register.html', context)
 

--- a/UniExplore/base/views.py
+++ b/UniExplore/base/views.py
@@ -120,7 +120,7 @@ def registerPage(request):
                 messages.success(request, f'Account created for {username}!')
                 return redirect('home')
 
-            messages.warning(request, "User with this email already exists")
+            messages.warning(request, "A User with this email already exists")
             return redirect('login')
             
 


### PR DESCRIPTION
To test:
- try and create a user with a non-Exeter email
- should be redirected to the login page
- create a user with an Exeter email (ending in exeter.ac.uk) 
- should create a new user successfully

Details:
- only users can register with exeter emails 