### PR TITLE
Add button to make users accept terms and conditions before proceeding

### DIFF
--- a/UniExplore/base/templates/base/login_register.html
+++ b/UniExplore/base/templates/base/login_register.html
@@ -264,6 +264,9 @@ h1 {
 
           </fieldset>
           <div class="form-group">
+            <input type="checkbox" value="Accept Terms and Conditions" required>
+            <label for="Accept Terms and Conditions">Accept <a href = "{% url 'ToS' %}" target=”_blank”>Terms of Service</a></label>
+            <br>
             <input type="submit" value="Create Account"/>
 
           </div>


### PR DESCRIPTION
What I've done: 
- Add button in register form to make users accept terms and conditions before proceeding

To test: 
- Go to register a new user. 
- Fill out all details other than the t&c checkbox 
- Click submit
- It should stop you submitting 
- Click the checkbox 
- You should now have created a new user 