### PR TITLE
Fixed total point count on other user's profiles, fixed links to profiles

### DIFF
--- a/UniExplore/base/templates/base/profile.html
+++ b/UniExplore/base/templates/base/profile.html
@@ -100,7 +100,7 @@ $(document).ready(function () {
 
 <div class="challenges">
     <h1>{{user.username}}'s Completed Challenges</h1>
-    <h4>Total Points: {{request.user.profile.points}}</h4>
+    <h4>Total Points: {{user.profile.points}}</h4>
 
     {% for response in responses %}
     <div class="challenge">

--- a/UniExplore/base/views/challanges_and_responses.py
+++ b/UniExplore/base/views/challanges_and_responses.py
@@ -1,5 +1,8 @@
 from email.headerregistry import Group
 from http.client import responses
+
+from django.http import HttpResponseRedirect
+
 from ..decorators import allowed_users
 from decouple import config
 from ..forms import ChallengeForm, ResponseForm
@@ -155,10 +158,9 @@ def myResponses(request):
 @login_required(login_url='/login')
 def userResponses(request, pk):
     user = User.objects.get(id=pk)
-    responses = Responses.objects.filter(user=user).order_by('-created')
-    categories = Category.objects.all()
-    context = {'responses': responses, 'user': user, 'categories': categories}
-    return render(request, 'base/userResponses.html', context)
+    username = user.username
+
+    return HttpResponseRedirect("/profile/"+username)
 
 
 


### PR DESCRIPTION

What I've done:
- Changed the code for userResponses function so it now forwards to the user's profile
- 

How to test:
- Check your profile and another user's profile, ensure that different point counts are shown (before it would only ever show your point count
- Click on a user's name on any post, comment, etc. Make sure it takes you to their profile page